### PR TITLE
endian 该翻译成字节序

### DIFF
--- a/buffer/buf_readdoublele_offset_noassert.md
+++ b/buffer/buf_readdoublele_offset_noassert.md
@@ -6,9 +6,9 @@ added: v0.11.15
 * `noAssert` {Boolean} 是否跳过 `offset` 检验？**默认:** `false`
 * 返回: {Number}
 
-用指定的尾数格式（`readDoubleBE()` 返回大尾数，`readDoubleLE()` 返回小尾数）从 `buf` 中指定的 `offset` 读取一个64位双精度值。
+用指定的字节序格式（`readDoubleBE()` 返回大端序，`readDoubleLE()` 返回小端序）从 `buf` 中指定的 `offset` 读取一个64位双精度值。
 
-设置 `noAssert` 为 `true` 则 `offset` 可超出 `buf` 的末尾，但后果是不确定的。
+设置 `noAssert` 为 `true` 则 `offset` 可超出 `buf` 的最后一位字节，但后果是不确定的。
 
 例子：
 
@@ -24,7 +24,7 @@ console.log(buf.readDoubleLE());
 // 抛出异常: RangeError: Index out of range
 console.log(buf.readDoubleLE(1));
 
-// 警告: 读取超出 buffer 的末尾！
+// 警告: 读取超出 buffer 的最后一位字节！
 // 这会导致内存区段错误！不要这么做！
 console.log(buf.readDoubleLE(1, true));
 ```


### PR DESCRIPTION
endian不该翻译成尾数，以免造成误解。这里该明确指出是大端和小端的问题。