### PR TITLE
Update querystring_stringify_obj_sep_eq_options.md

### DIFF
--- a/querystring/querystring_stringify_obj_sep_eq_options.md
+++ b/querystring/querystring_stringify_obj_sep_eq_options.md
@@ -10,9 +10,7 @@ added: v0.1.25
 
 `querystring.stringify()` 方法通过遍历对象的自有属性，从一个给定的 `obj` 产生一个 URL 查询字符串。
 
-It serializes the following types of values passed in `obj`:
-{string|number|boolean|string[]|number[]|boolean[]}
-Any other input values will be coerced to empty strings.
+如果'obj'中的属性为{string|number|boolean|string[]|number[]|boolean[]}类型，则对应属性值都会被正常处理或转换；如果'obj'中包含其他类型的属性，这些类型的属性值会被强制转换为空字符串。
 
 例子：
 


### PR DESCRIPTION
增加对如下描述的翻译：
It serializes the following types of values passed in obj: <string> | <number> | <boolean> | <string[]> | <number[]> | <boolean[]> Any other input values will be coerced to empty strings.