### PR TITLE
翻译URL 字符串与 URL 对象

### DIFF
--- a/url/url_strings_and_url_objects.md
+++ b/url/url_strings_and_url_objects.md
@@ -2,9 +2,12 @@
 一个 URL 字符串是一个结构化的字符串，它包含多个有意义的组成部分。
 当被解析时，会返回一个 URL 对象，它包含每个组成部分作为属性。
 
-The `url` module provides two APIs for working with URLs: a legacy API that is
+`url`模块提供了两套API来处理URLs：一个是Node.js遗留的特有的API,另一个则是通常使用在web浏览器中
+上线了[WHATWG URL Standard]的API.
+
+<!--The `url` module provides two APIs for working with URLs: a legacy API that is
 Node.js specific, and a newer API that implements the same
-[WHATWG URL Standard][] used by web browsers.
+[WHATWG URL Standard][] used by web browsers.-->
 
 *Note*: While the Legacy API has not been deprecated, it is maintained solely
 for backwards compatibility with existing applications. New application code
@@ -15,8 +18,9 @@ A comparison between the WHATWG and Legacy APIs is provided below. Above the URL
 an object returned by the legacy `url.parse()` are shown. Below it are
 properties of a WHATWG `URL` object.
 
-*Note*: WHATWG URL's `origin` property includes `protocol` and `host`, but not
-`username` or `password`.
+WHATWG URL的组织属性包括`protocol`和`host`,但不包含`username`、`password`.
+<!--*Note*: WHATWG URL's `origin` property includes `protocol` and `host`, but not
+`username` or `password`.-->
 
 ```txt
 ┌─────────────────────────────────────────────────────────────────────────────────────────────┐
@@ -39,20 +43,22 @@ properties of a WHATWG `URL` object.
 (请忽略字符串中的空格，它们只是为了格式化)
 ```
 
-Parsing the URL string using the WHATWG API:
-
+<!--Parsing the URL string using the WHATWG API:-->
+利用WHATWG API解析一个URL字符串:
 ```js
 const { URL } = require('url');
 const myURL =
   new URL('https://user:pass@sub.host.com:8080/p/a/t/h?query=string#hash');
 ```
+在浏览器中，WHATWG `URL`（超文本链接）在全局总是可用的，而在Node.js中，任何情况下打开
+或使用一个链接都必须事先引用'url'模块：`require('url').URL`
 
-*Note*: In Web Browsers, the WHATWG `URL` class is a global that is always
-available. In Node.js, however, the `URL` class must be accessed via
-`require('url').URL`.
+<!--*Note*: In Web Browsers, the WHATWG `URL` class is a global that is always
+ available. In Node.js, however, the `URL` class must be accessed via
+require('url').URL`.-->
 
-Parsing the URL string using the Legacy API:
-
+<!--Parsing the URL string using the Legacy API:-->
+通过Node.js提供的API解析一个URL:
 ```js
 const url = require('url');
 const myURL =

--- a/url/url_strings_and_url_objects.md
+++ b/url/url_strings_and_url_objects.md
@@ -3,7 +3,7 @@
 当被解析时，会返回一个 URL 对象，它包含每个组成部分作为属性。
 
 `url`模块提供了两套API来处理URLs：一个是Node.js遗留的特有的API,另一个则是通常使用在web浏览器中
-上线了[WHATWG URL Standard]的API.
+实现了[WHATWG URL Standard]的API.
 
 <!--The `url` module provides two APIs for working with URLs: a legacy API that is
 Node.js specific, and a newer API that implements the same
@@ -50,7 +50,7 @@ const { URL } = require('url');
 const myURL =
   new URL('https://user:pass@sub.host.com:8080/p/a/t/h?query=string#hash');
 ```
-在浏览器中，WHATWG `URL`（超文本链接）在全局总是可用的，而在Node.js中，任何情况下打开
+在浏览器中，WHATWG `URL`在全局总是可用的，而在Node.js中，任何情况下打开
 或使用一个链接都必须事先引用'url'模块：`require('url').URL`
 
 <!--*Note*: In Web Browsers, the WHATWG `URL` class is a global that is always


### PR DESCRIPTION
翻译URL 字符串与 URL 对象，URL使用的两套API以及具体实现代码