### PR TITLE
Update script_runinnewcontext_sandbox_options.md

### DIFF
--- a/vm/script_runinnewcontext_sandbox_options.md
+++ b/vm/script_runinnewcontext_sandbox_options.md
@@ -3,28 +3,17 @@ added: v0.3.1
 -->
 
 * `sandbox` {Object} An object that will be [contextified][]. If `undefined`, a
-  new object will be created.
+  new object will be created. 一个将被[`contextified`][]的对象。如果是`undefined`, 会生成一个新的对象
 * `options` {Object}
-  * `filename` {string} Specifies the filename used in stack traces produced
-    by this script.
-  * `lineOffset` {number} Specifies the line number offset that is displayed
-    in stack traces produced by this script.
-  * `columnOffset` {number} Specifies the column number offset that is displayed
-    in stack traces produced by this script.
-  * `displayErrors` {boolean} When `true`, if an [`Error`][] error occurs
-    while compiling the `code`, the line of code causing the error is attached
-    to the stack trace.
-  * `timeout` {number} Specifies the number of milliseconds to execute `code`
-    before terminating execution. If execution is terminated, an [`Error`][]
-    will be thrown.
+  * `filename` {string} 定义供脚本生成的堆栈跟踪信息所使用的文件名
+  * `lineOffset` {number} 定义脚本生成的堆栈跟踪信息所显示的行号偏移
+  * `columnOffset` {number} 定义脚本生成的堆栈跟踪信息所显示的列号偏移
+  * `displayErrors` {boolean} 当值为真的时候，假如在解析代码的时候发生错误[`Error`][]，引起错误的行将会被加入堆栈跟踪信息
+  * `timeout` {number} 定义在被终止执行之前此code被允许执行的最大毫秒数。假如执行被终止，将会抛出一个错误[`Error`][]。
 
-First contextifies the given `sandbox`, runs the compiled code contained by
-the `vm.Script` object within the created sandbox, and returns the result.
-Running code does not have access to local scope.
+首先给指定的`sandbox`提供一个隔离的上下文, 再在此上下文中执行`vm.Script`中被编译的代码，最后返回结果。运行中的代码无法获取本地作用域。
 
-The following example compiles code that sets a global variable, then executes
-the code multiple times in different contexts. The globals are set on and
-contained within each individual `sandbox`.
+以下的例子会编译一段代码，该代码会递增一个全局变量，给另外一个全局变量赋值。同时该代码被编译后会被多次执行。全局变量会被置于各个独立的`sandbox`对象内。
 
 ```js
 const util = require('util');


### PR DESCRIPTION
针对将“contextify”翻译成"隔离上下文"的翻译的一点想法：
原本想简单的使用“上下文化”来翻译它，但感觉不能体现出contextify是要为用户的JavaScript代码提供一个独立，相互隔离的作用域的意思，所以干脆加上了“隔离”二字。