### PR TITLE
fix code typo about init method name

### DIFF
--- a/addons/hello_world.md
+++ b/addons/hello_world.md
@@ -29,7 +29,7 @@ void init(Local<Object> exports) {
   NODE_SET_METHOD(exports, "hello", Method);
 }
 
-NODE_MODULE(NODE_GYP_MODULE_NAME, Init)
+NODE_MODULE(NODE_GYP_MODULE_NAME, init)
 
 }  // namespace demo
 ```


### PR DESCRIPTION
Capitalize the first letter of `Init` can passed the `node-gyp configure` but will cause an error when `node-gyp build`, I'm wonder about why it can pass `node-gyp configure`, but at least this typo need to be correct.