### PR TITLE
add translations which is missing from the english version

### DIFF
--- a/api-docs/4ae2c1a36dfdc4a12a69dadd197939411b7eb1703586d21b597f84f04847af5b.md
+++ b/api-docs/4ae2c1a36dfdc4a12a69dadd197939411b7eb1703586d21b597f84f04847af5b.md
@@ -2,7 +2,7 @@
 added: v5.10.0
 -->
 
-使用 `--zero-fill-buffers` 命令行选项时，`new Buffer(size)`、[`Buffer.allocUnsafe()`] 、[`Buffer.allocUnsafeSlow()`] 或 `new SlowBuffer(size)` 返回的 `Buffer` 在创建时会用 0 填充。
+使用 `--zero-fill-buffers` 命令行选项时，`new Buffer(size)`、[`Buffer.allocUnsafe()`] 、[`Buffer.allocUnsafeSlow()`] 或 `new SlowBuffer(size)` 返回的 `Buffer` 在创建时会用 0 填充。开启这个选项会导致明显的性能下降，除非你需要确保所有新分配的 `Buffer` 实例不包含任何先前 `Buffer` 实例中的潜在敏感数据。
 
 ```txt
 $ node --zero-fill-buffers


### PR DESCRIPTION
中文版本缺少这段文字的翻译：

> Use of this flag can have a significant negative impact on performance. Use of the --zero-fill-buffers option is recommended only when necessary to enforce that newly allocated Buffer instances cannot contain old data that is potentially sensitive.