### PR TITLE
Update 036b75b27ce96ca229d4387f0e0b9a2847986b29338c37f6488d4ae2a4906e…

### DIFF
--- a/api-docs/036b75b27ce96ca229d4387f0e0b9a2847986b29338c37f6488d4ae2a4906e77.md
+++ b/api-docs/036b75b27ce96ca229d4387f0e0b9a2847986b29338c37f6488d4ae2a4906e77.md
@@ -18,8 +18,7 @@
 
 所有的 [`net.Socket`] 都被设置为 `SO_REUSEADDR` (详见 [`socket(7)`])。
 
-当且仅当在第一次调用 `server.listen()` 或调用 `server.close()` 期间出现错误时，才能再次调用 `server.listen()` 方法。
-否则，将抛出 `ERR_SERVER_ALREADY_LISTEN` 错误。
+当且仅当上次调用`server.listen()`发生错误或已经调用`server.close()`时，才能再次调用`server.listen()`方法。否则将抛出 `ERR_SERVER_ALREADY_LISTEN` 错误。
 
 监听时最常见的错误之一是 `EADDRINUSE`。
 这是因为另一个服务器已正在监听请求的 `port`/`path`/`handle`。


### PR DESCRIPTION
…77.md

翻译存在逻辑错误，什么叫：“调用 `server.close()` 期间出现错误时，才能再次调用 `server.listen()` 方法”？

另外原文中的`first`应该不是指第一次，而是上一次